### PR TITLE
Explicit Aeson.ToJSON.toEncoding Implementations

### DIFF
--- a/src/Haspara/Accounting/Account.hs
+++ b/src/Haspara/Accounting/Account.hs
@@ -69,6 +69,7 @@ instance Aeson.FromJSON AccountKind where
 
 instance Aeson.ToJSON AccountKind where
   toJSON = Aeson.genericToJSON $ aesonOptionsForSingleTag "AccountKind"
+  toEncoding = Aeson.genericToEncoding $ aesonOptionsForSingleTag "AccountKind"
 
 
 -- | Provides textual representation of a given 'AccountKind'.
@@ -125,3 +126,4 @@ instance Aeson.FromJSON o => Aeson.FromJSON (Account o) where
 
 instance Aeson.ToJSON o => Aeson.ToJSON (Account o) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "account"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "account"

--- a/src/Haspara/Accounting/Amount.hs
+++ b/src/Haspara/Accounting/Amount.hs
@@ -54,6 +54,7 @@ instance KnownNat precision => Aeson.FromJSON (Amount precision) where
 -- Right (Amount {amountSide = SideCredit, amountValue = Refined 42.00})
 instance KnownNat precision => Aeson.ToJSON (Amount precision) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "amount"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "amount"
 
 
 -- | Returns the debit value of the 'Amount', if any.

--- a/src/Haspara/Accounting/Balance.hs
+++ b/src/Haspara/Accounting/Balance.hs
@@ -63,9 +63,9 @@ instance KnownNat precision => Aeson.FromJSON (Balance precision) where
 -- >>> import Haspara.Accounting.Side
 -- >>> import Haspara.Quantity
 -- >>> Aeson.encode (Balance SideDebit (mkQuantity 42 :: Quantity 2) def)
--- "{\"inventory\":{\"current\":[],\"history\":[],\"total\":0.0},\"side\":\"db\",\"value\":42.0}"
+-- "{\"side\":\"db\",\"value\":42.0,\"inventory\":{\"total\":0.0,\"current\":[],\"history\":[]}}"
 -- >>> Aeson.encode (Balance SideCredit (mkQuantity 42 :: Quantity 2) def)
--- "{\"inventory\":{\"current\":[],\"history\":[],\"total\":0.0},\"side\":\"cr\",\"value\":42.0}"
+-- "{\"side\":\"cr\",\"value\":42.0,\"inventory\":{\"total\":0.0,\"current\":[],\"history\":[]}}"
 -- >>> Aeson.eitherDecode (Aeson.encode (Balance SideDebit (mkQuantity 42 :: Quantity 2) def)) :: Either String (Balance 2)
 -- Right (Balance {balanceSide = SideDebit, balanceValue = 42.00, balanceInventory = MkInventory {inventoryTotal = 0.000000000000, inventoryCurrent = fromList [], inventoryHistory = fromList []}})
 -- >>> Aeson.eitherDecode (Aeson.encode (Balance SideCredit (mkQuantity 42 :: Quantity 2) def)) :: Either String (Balance 2)
@@ -74,15 +74,16 @@ instance KnownNat precision => Aeson.FromJSON (Balance precision) where
 -- For negative balances:
 --
 -- >>> Aeson.encode (Balance SideDebit (mkQuantity (-42) :: Quantity 2) def)
--- "{\"inventory\":{\"current\":[],\"history\":[],\"total\":0.0},\"side\":\"db\",\"value\":-42.0}"
+-- "{\"side\":\"db\",\"value\":-42.0,\"inventory\":{\"total\":0.0,\"current\":[],\"history\":[]}}"
 -- >>> Aeson.encode (Balance SideCredit (mkQuantity (-42) :: Quantity 2) def)
--- "{\"inventory\":{\"current\":[],\"history\":[],\"total\":0.0},\"side\":\"cr\",\"value\":-42.0}"
+-- "{\"side\":\"cr\",\"value\":-42.0,\"inventory\":{\"total\":0.0,\"current\":[],\"history\":[]}}"
 -- >>> Aeson.eitherDecode (Aeson.encode (Balance SideDebit (mkQuantity (-42) :: Quantity 2) def)) :: Either String (Balance 2)
 -- Right (Balance {balanceSide = SideDebit, balanceValue = -42.00, balanceInventory = MkInventory {inventoryTotal = 0.000000000000, inventoryCurrent = fromList [], inventoryHistory = fromList []}})
 -- >>> Aeson.eitherDecode (Aeson.encode (Balance SideCredit (mkQuantity (-42) :: Quantity 2) def)) :: Either String (Balance 2)
 -- Right (Balance {balanceSide = SideCredit, balanceValue = -42.00, balanceInventory = MkInventory {inventoryTotal = 0.000000000000, inventoryCurrent = fromList [], inventoryHistory = fromList []}})
 instance KnownNat precision => Aeson.ToJSON (Balance precision) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "balance"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "balance"
 
 
 -- | Returns the debit quantity, if any.

--- a/src/Haspara/Accounting/Inventory.hs
+++ b/src/Haspara/Accounting/Inventory.hs
@@ -55,6 +55,7 @@ instance (KnownNat pprec, KnownNat sprec, KnownNat vprec) => Aeson.FromJSON (Inv
 
 instance (KnownNat pprec, KnownNat sprec, KnownNat vprec) => Aeson.ToJSON (Inventory pprec sprec vprec) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "inventory"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "inventory"
 
 
 -- | Data definition for inventory events.
@@ -77,6 +78,7 @@ instance (KnownNat pprec, KnownNat sprec) => Aeson.FromJSON (InventoryEvent ppre
 
 instance (KnownNat pprec, KnownNat sprec) => Aeson.ToJSON (InventoryEvent pprec sprec) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "inventoryEvent"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "inventoryEvent"
 
 
 -- | Data definition for PnL-taking inventory history items.
@@ -110,6 +112,7 @@ instance (KnownNat pprec, KnownNat sprec, KnownNat vprec) => Aeson.FromJSON (Inv
 
 instance (KnownNat pprec, KnownNat sprec, KnownNat vprec) => Aeson.ToJSON (InventoryHistoryItem pprec sprec vprec) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "inventoryHistoryItem"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "inventoryHistoryItem"
 
 
 -- * Operations

--- a/src/Haspara/Accounting/Journal.hs
+++ b/src/Haspara/Accounting/Journal.hs
@@ -35,6 +35,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (Journal precision account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "journal"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "journal"
 
 
 -- | Data definition for a journal entry.
@@ -57,6 +58,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (JournalEntry precision account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "journalEntry"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "journalEntry"
 
 
 -- | Returns the total debit amount of a journal entry.
@@ -118,6 +120,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (JournalEntryItem precision account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "journalEntryItem"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "journalEntryItem"
 
 
 -- | Data definition for inventory event.
@@ -135,6 +138,7 @@ instance (Aeson.FromJSON account, Aeson.FromJSON event) => Aeson.FromJSON (Journ
 
 instance (Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (JournalEntryItemInventoryEvent account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "journalEntryItemInventoryEvent"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "journalEntryItemInventoryEvent"
 
 
 -- | Creates a 'JournalEntryItem' from the given signed /value/, the account it

--- a/src/Haspara/Accounting/Ledger.hs
+++ b/src/Haspara/Accounting/Ledger.hs
@@ -40,6 +40,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (GeneralLedger precision account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "generalLedger"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "generalLedger"
 
 
 -- | Data definition for a ledger.
@@ -58,6 +59,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (Ledger precision account event) where
   -- TODO: Add ledgerClosing, too.
   toJSON = Aeson.genericToJSON $ commonAesonOptions "ledger"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "ledger"
 
 
 -- | Returns the closing balance of a ledger.
@@ -86,6 +88,7 @@ instance (KnownNat precision, Aeson.FromJSON event) => Aeson.FromJSON (LedgerEnt
 
 instance (KnownNat precision, Aeson.ToJSON event) => Aeson.ToJSON (LedgerEntry precision event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "ledgerEntry"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "ledgerEntry"
 
 
 -- | Initializes an empty ledger for a given account.

--- a/src/Haspara/Accounting/Side.hs
+++ b/src/Haspara/Accounting/Side.hs
@@ -14,6 +14,7 @@
 module Haspara.Accounting.Side where
 
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encoding as Aeson.Encoding
 import qualified Data.Text as T
 import GHC.TypeLits (KnownNat)
 import Haspara.Accounting.Account (AccountKind (..))
@@ -54,6 +55,10 @@ instance Aeson.FromJSON Side where
 instance Aeson.ToJSON Side where
   toJSON SideDebit = Aeson.String "db"
   toJSON SideCredit = Aeson.String "cr"
+
+
+  toEncoding SideDebit = Aeson.Encoding.text "db"
+  toEncoding SideCredit = Aeson.Encoding.text "cr"
 
 
 -- | Gives the other side.

--- a/src/Haspara/Accounting/TrialBalance.hs
+++ b/src/Haspara/Accounting/TrialBalance.hs
@@ -29,6 +29,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (TrialBalance precision account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "trialBalance"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "trialBalance"
 
 
 -- | Data definition for a trial balance item.
@@ -45,6 +46,7 @@ instance (KnownNat precision, Aeson.FromJSON account, Aeson.FromJSON event) => A
 
 instance (KnownNat precision, Aeson.ToJSON account, Aeson.ToJSON event) => Aeson.ToJSON (TrialBalanceItem precision account event) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "trialBalanceItem"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "trialBalanceItem"
 
 
 -- | Returns the amount of the trial balance item. This is a simple conversion

--- a/src/Haspara/Currency.hs
+++ b/src/Haspara/Currency.hs
@@ -10,6 +10,7 @@ module Haspara.Currency where
 
 import Control.Monad.Except (MonadError (throwError))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encoding as Aeson.Encoding
 import Data.Hashable (Hashable)
 import Data.String (IsString (..))
 import qualified Data.Text as T
@@ -87,6 +88,7 @@ instance Aeson.FromJSON Currency where
 -- "\"USD\""
 instance Aeson.ToJSON Currency where
   toJSON (MkCurrency c) = Aeson.String c
+  toEncoding (MkCurrency c) = Aeson.Encoding.text c
 
 
 -- | Smart constructor for 'Currency' values within 'MonadError' context.
@@ -185,6 +187,7 @@ instance Aeson.FromJSON CurrencyPair where
 
 instance Aeson.ToJSON CurrencyPair where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "currencyPair"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "currencyPair"
 
 
 -- | 'Show' instance for 'CurrencyPair'.

--- a/src/Haspara/FxQuote.hs
+++ b/src/Haspara/FxQuote.hs
@@ -50,6 +50,7 @@ instance KnownNat s => Aeson.FromJSON (FxQuote s) where
 
 instance KnownNat s => Aeson.ToJSON (FxQuote s) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "fxQuote"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "fxQuote"
 
 
 -- | Smart constructor for 'FxQuote' values within @'MonadError' 'T.Text'@

--- a/src/Haspara/Monetary.hs
+++ b/src/Haspara/Monetary.hs
@@ -45,6 +45,7 @@ instance KnownNat s => Aeson.FromJSON (Money s) where
 
 instance KnownNat s => Aeson.ToJSON (Money s) where
   toJSON = Aeson.genericToJSON $ commonAesonOptions "money"
+  toEncoding = Aeson.genericToEncoding $ commonAesonOptions "money"
 
 
 -- | Type encoding of a monetary context.

--- a/src/Haspara/Quantity.hs
+++ b/src/Haspara/Quantity.hs
@@ -18,6 +18,7 @@ module Haspara.Quantity where
 import Control.Applicative (liftA2)
 import Control.Monad.Except (MonadError (throwError))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encoding as Aeson.Encoding
 import Data.Either (fromRight)
 import Data.Proxy (Proxy (..))
 import Data.Scientific (FPFormat (Fixed), Scientific, formatScientific)
@@ -100,6 +101,7 @@ instance (KnownNat s) => Aeson.FromJSON (Quantity s) where
 -- "0.42"
 instance (KnownNat s) => Aeson.ToJSON (Quantity s) where
   toJSON = Aeson.Number . D.toScientificDecimal . unQuantity
+  toEncoding = Aeson.Encoding.scientific . D.toScientificDecimal . unQuantity
 
 
 -- | Numeric arithmetic over 'Quantity' values.


### PR DESCRIPTION
For large data, encoding was using massive amounts of memory due to
intermediate Aeson.Value values.

Now, we are much more space efficient. I am not 100% sure, about
runtime performance.
