### PR TITLE
Make it more convenient to test against different GHC versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cabal.project.local~
 cabal.sandbox.config
 dist
 dist-*
+
+## Nix stuff:
+/result

--- a/README.md
+++ b/README.md
@@ -13,6 +13,28 @@
 *haspara* is a Haskell library that provides monetary definitions and a
 rudimentary (and experimental) accounting functionality.
 
+## Supported GHC Versions
+
+1. `ghc90`
+1. `ghc92`
+
+At the moment, there is no particular reason for not supporting
+`ghc94` except that required settings are not done yet in Nix support
+files, in particular for Cabal dependency.
+
+## Testing Against GHC Versions
+
+You can use Nix support to test against different GHC versions:
+
+```sh
+nix-build --arg compiler "\"ghc92\""
+nix-build --arg compiler "\"ghc90\""
+```
+
+`nix-build` command will default to `ghc90`. Check `./default.nix`
+file for the default `ghc` version in case that this documentation is
+out of date.
+
 ## Development
 
 Before committing code to repository, reformat the code:
@@ -65,6 +87,8 @@ weeder --require-hs-files
     cabal build -O0
     cabal test -O0
     cabal haddock -O0
+    nix-build --arg compiler "\"ghc92\""
+    nix-build --arg compiler "\"ghc90\""
     ```
 
 4. Update [CHANGELOG.md](./CHANGELOG.md) file:

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{ compiler ? "ghc90"
+, ...
+}:
+
+
+let
+  nix = import ./nix { compiler = compiler; };
+in
+nix.thisPackage

--- a/haspara.cabal
+++ b/haspara.cabal
@@ -54,15 +54,15 @@ library
     , containers >=0.6.4.1 && <0.7
     , data-default ==0.7.*
     , exceptions >=0.10.4 && <0.11
-    , hashable >=1.3.0.0 && <1.4
+    , hashable >=1.3.0.0 && <1.5
     , megaparsec >=9.0.1 && <9.3
     , mtl >=2.2.2 && <2.3
     , refined >=0.6.3 && <0.7
     , safe-decimal >=0.2.1.0 && <0.3
     , scientific >=0.3.7.0 && <0.4
-    , template-haskell >=2.16.0.0 && <2.18
+    , template-haskell >=2.16.0.0 && <2.19
     , text >=1.2.4.1 && <1.3
-    , time >=1.9.3 && <1.10
+    , time >=1.9.3 && <1.12
   default-language: Haskell2010
 
 test-suite haspara-doctest

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -20,7 +20,7 @@ let
     };
 
   ## Get this package:
-  thisPackage = haskell.callCabal2nixWithOptions "haspara" ../. "--no-haddock" { };
+  thisPackage = haskell.callCabal2nix "haspara" ../. { };
 
   ## Get this package's Haskell dependencies:
   thisPackageDeps = pkgs.haskell.lib.compose.getHaskellBuildInputs thisPackage;

--- a/package.yaml
+++ b/package.yaml
@@ -27,15 +27,15 @@ library:
   - containers >=0.6.4.1 && <0.7
   - data-default >= 0.7 && <0.8
   - exceptions >=0.10.4 && <0.11
-  - hashable >=1.3.0.0 && <1.4
+  - hashable >=1.3.0.0 && <1.5
   - megaparsec >=9.0.1 && <9.3
   - mtl >=2.2.2 && <2.3
   - refined >=0.6.3 && <0.7
   - safe-decimal >=0.2.1.0 && <0.3
   - scientific >=0.3.7.0 && <0.4
-  - template-haskell >=2.16.0.0 && <2.18
+  - template-haskell >=2.16.0.0 && <2.19
   - text >=1.2.4.1 && <1.3
-  - time >=1.9.3 && <1.10
+  - time >=1.9.3 && <1.12
 
 tests:
   haspara-test:


### PR DESCRIPTION
Closes #15.

- chore(nix): make default haspara Nix package come with haddock
- fix(deps): support ghc92
- chore(nix): make it more convenient to test against different ghc versions
